### PR TITLE
EditableHeader created.

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -36,13 +36,13 @@
     - Returns editable header zone on all editable pages.
   - Returns one editable block as default.
   - When you press enter inside of an editable block, it duplicates the block (but empty) on the next line.
-- **Editable header zone:**
+- **Editable header zone: DONE.**
   - Static icon field. DONE.
     - Editable icon field.
   - Static title field. DONE.
     - Editable title field. DONE (VERSION 1, SEE NOTES).
   - Static cover field. DONE.
-    - Editable cover field.
+    - Editable cover field. DONE.
 - **Editable block:**
   - The Notion editable block features:
     - When you use the slash command, you can select the block type.
@@ -155,8 +155,14 @@ Will be working towards achieving the above.
 
 - Got it done! First time I've really gotten how to make components fully reuseable as well. Took a lot of fiddling around with PopUp and Button, and they are absolutely not clean at all, but this was a concept I was struggling with since they first told us about it, so I'm pretty pleased, even if the code is hideous.
 
-After dinner TODO:
+TODO:
 
 - Make it so that the button for changing the header disappears when you mouse away from the header image itself, but still remains clickable.
 - Maybe try out some code so that you can dynamically update the favicon and tab title with the page icon and title?
 - Alternatively, just have a crack at cleaning up some different components. Review plan!
+
+Having reviewed plan, going to focus on:
+
+- Making the button disappear when you move away from the header image, but also remain clickable with the onmouseover and onmouseout.
+  - Had a brainwave. Realised I could literally just do this with hover in CSS. Don't know why I was agonising over making state for it, unreal scenes.
+  - Fixed it, though! Just need to actually tidy up some of the CSS so it's less ugly, but i think the functionality of the EditableHeader (the basic functionality) is done? Will check.

--- a/LOG.md
+++ b/LOG.md
@@ -37,11 +37,11 @@
   - Returns one editable block as default.
   - When you press enter inside of an editable block, it duplicates the block (but empty) on the next line.
 - **Editable header zone:**
-  - Static icon field.
+  - Static icon field. DONE.
     - Editable icon field.
-  - Static title field.
-    - Editable title field.
-  - Static cover field.
+  - Static title field. DONE.
+    - Editable title field. DONE (VERSION 1, SEE NOTES).
+  - Static cover field. DONE.
     - Editable cover field.
 - **Editable block:**
   - The Notion editable block features:
@@ -65,3 +65,53 @@
   - Maybe also because when there's no source provided for an image, a visual error displays, but that doesn't happen with spans?
 - The cover, however, is just an image. To change that, you need to go through a few more sub-menus and select new options and perform an upload.
 - Setting the font-size on the span for the header icon is how you change the size of the emoji, as it's read as a font (I think)!
+- Similar to above weird choices (or choices I don't understand yet), the header text on Notion is just a div with a set placeholder. Using an input is going kind of weird, so will try that!
+- Figured out the input and types, but now nothing shows when the page compiles, which is so fun.
+- Figured out why it wasn't showing: had something between the input tags, like a fool.
+- On Notion, when you type a title for a page that exceeds the size of the input field, it stretches and continues onto a new line. Will attempt to implement that now! Think the input would need to be a textarea to be multiline? Will Google.
+  - I was correct. Will make a textarea.
+- Got it working properly, but the CSS is kind of nightmarish and I can't be bothered figuring it out right now, would rather make some more functional things. So! Going to save the code I had in a code block here for it, and then just put a limit on how many characters can be entered into an input.
+
+```typescript
+export default function EditableHeader() {
+  const [headerText, setHeaderText] = useState("Untitled");
+
+  function onChange(e: React.ChangeEvent) {
+    setHeaderText((e.target as HTMLTextAreaElement).value);
+  }
+
+  function onInput(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    if (e.target.scrollHeight > 33) {
+      e.target.style.height = "5px";
+      e.target.style.height = e.target.scrollHeight - 16 + "px";
+    }
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" || e.key === "Escape") {
+      (e.target as HTMLTextAreaElement).blur();
+    }
+  }
+
+  return (
+    <div className="EditableHeader">
+      <img
+        alt="Decorative header background."
+        src="https://www.nasa.gov/sites/default/files/styles/full_width/public/thumbnails/image/main_image_star-forming_region_carina_nircam_final-1280.jpg"
+        className="headerImage"
+      />
+      <span className="headerIcon">⭐️</span>
+      <textarea
+        value={headerText}
+        onChange={onChange}
+        onInput={onInput}
+        onKeyDown={onKeyDown}
+        rows={1}
+        className="headerTitle"
+      ></textarea>
+    </div>
+  );
+}
+```
+
+- Set maxLength to 11, which is a bit short, but read somewhere that the widest letter is capitalised W, and 11 capitalised Ws fit, so it is what it is.

--- a/LOG.md
+++ b/LOG.md
@@ -115,3 +115,18 @@ export default function EditableHeader() {
 ```
 
 - Set maxLength to 11, which is a bit short, but read somewhere that the widest letter is capitalised W, and 11 capitalised Ws fit, so it is what it is.
+
+On the fly notes copied from component plan:
+
+- Editable icon field. WORKING ON THIS NOW.
+  - You click the icon.
+  - A menu of other emoji icons comes up.
+  - You select from the icons.
+  - The icon is set as the icon in the header, and the icon in the metadata.
+  - There's a lot more functionality, and you can set images, but I can worry about this later.
+  - So, recreating:
+    - You click on the icon.
+    - A menu comes up.
+    - Menu contains a dictionary of icons that you can select and use.
+    - On click, the selected icon is set as state for the main icon.
+    - This state should also be used to set the metadata of the EditablePage, so will need to be raised later?

--- a/LOG.md
+++ b/LOG.md
@@ -55,3 +55,13 @@
   - `<img>` block.
 
 ### Coding Log
+
+- Started building the editable header component on a new branch.
+- Started making the static version first. Was wondering how Notion dealt with the images for the selectable icons, turns out they're listed as spans in the code? Inside of two divs? One of those divs has a button role? With font family styling for emojis applied to them, and then the emoji itself changes between the span tags?
+  - Not sure why, but I'm sure I'll find out.
+  - Maybe so that the image can be selected and altered?
+  - Potentially the CSS is easier if it's being treated as a more text-like element than an image element? Maybe not though?
+  - Maybe because the icon in the tab becomes the same emoji as whatever you select for the page icon, and it's easier to convert to that one line of SVG emoji code if it's formatted as a span? You can just copy it over to wherever it needs to be inside the metadata?
+  - Maybe also because when there's no source provided for an image, a visual error displays, but that doesn't happen with spans?
+- The cover, however, is just an image. To change that, you need to go through a few more sub-menus and select new options and perform an upload.
+- Setting the font-size on the span for the header icon is how you change the size of the emoji, as it's read as a font (I think)!

--- a/LOG.md
+++ b/LOG.md
@@ -130,3 +130,12 @@ On the fly notes copied from component plan:
     - Menu contains a dictionary of icons that you can select and use.
     - On click, the selected icon is set as state for the main icon.
     - This state should also be used to set the metadata of the EditablePage, so will need to be raised later?
+
+Thu 8th Sept
+
+- Back on it!
+- Made a PopUp component which is rendered inside of EditableHeader. When you click the icon in the header, it renders the pop up component, and lets you select a new icon for the document from a provided list.
+- Took a while to get the onClick on the pop up for setting the icon state to work, but! Fixed it in the end!
+- Still need to:
+  - Use the state for the current icon to update the page metadata, so the favicon is the icon.
+  - Make the CSS for updating the icon apply properly.

--- a/LOG.md
+++ b/LOG.md
@@ -118,7 +118,7 @@ export default function EditableHeader() {
 
 On the fly notes copied from component plan:
 
-- Editable icon field. WORKING ON THIS NOW.
+- Editable icon field.
   - You click the icon.
   - A menu of other emoji icons comes up.
   - You select from the icons.
@@ -131,13 +131,24 @@ On the fly notes copied from component plan:
     - On click, the selected icon is set as state for the main icon.
     - This state should also be used to set the metadata of the EditablePage, so will need to be raised later?
 
-Thu 8th Sept
+**Thu 8th Sept**
 
 - Back on it!
 - Made a PopUp component which is rendered inside of EditableHeader. When you click the icon in the header, it renders the pop up component, and lets you select a new icon for the document from a provided list.
 - Took a while to get the onClick on the pop up for setting the icon state to work, but! Fixed it in the end!
 - Still need to:
   - Use the state for the current icon to update the page metadata, so the favicon is the icon.
+    - Just seems like this is gonna be crunchy, so setting aside for now.
   - Make the CSS for updating the icon apply properly.
     - CSS wasn't working because I'd forgotten to import it again, unreal.
-- Lorem.
+- Working on making the cover image on the page editable now.
+  - As with rest of interactive functionality in the EditableHeader, it's not a firm match to all the Notion functionality, but it's the basics. Can add complexity later, but you can't add complexity to what's not there.
+
+Copied plan:
+
+- Editable cover field.
+  - On Notion, when you hover over the header cover, a button to 'Change cover' comes up.
+  - If you click to change cover, it brings up another pop up.
+  - You select the cover you want from the pop up 'Gallery', and the cover updates.
+
+Will be working towards achieving the above.

--- a/LOG.md
+++ b/LOG.md
@@ -139,3 +139,5 @@ Thu 8th Sept
 - Still need to:
   - Use the state for the current icon to update the page metadata, so the favicon is the icon.
   - Make the CSS for updating the icon apply properly.
+    - CSS wasn't working because I'd forgotten to import it again, unreal.
+- Lorem.

--- a/LOG.md
+++ b/LOG.md
@@ -152,3 +152,11 @@ Copied plan:
   - You select the cover you want from the pop up 'Gallery', and the cover updates.
 
 Will be working towards achieving the above.
+
+- Got it done! First time I've really gotten how to make components fully reuseable as well. Took a lot of fiddling around with PopUp and Button, and they are absolutely not clean at all, but this was a concept I was struggling with since they first told us about it, so I'm pretty pleased, even if the code is hideous.
+
+After dinner TODO:
+
+- Make it so that the button for changing the header disappears when you mouse away from the header image itself, but still remains clickable.
+- Maybe try out some code so that you can dynamically update the favicon and tab title with the page icon and title?
+- Alternatively, just have a crack at cleaning up some different components. Review plan!

--- a/src/assets/headers.js
+++ b/src/assets/headers.js
@@ -1,12 +1,14 @@
 let headers = [
   {
     name: "starry",
-    imageURL:
+    image:
       "https://www.nasa.gov/sites/default/files/styles/full_width/public/thumbnails/image/main_image_star-forming_region_carina_nircam_final-1280.jpg",
+    representation: "Starry",
   },
   {
     name: "aquarium",
-    imageURL: "https://i.ytimg.com/vi/dEZu8u8qPb8/maxresdefault.jpg",
+    image: "https://i.ytimg.com/vi/dEZu8u8qPb8/maxresdefault.jpg",
+    representation: "Aquarium",
   },
 ];
 

--- a/src/assets/headers.js
+++ b/src/assets/headers.js
@@ -1,0 +1,13 @@
+let headers = [
+  {
+    name: "starry",
+    imageURL:
+      "https://www.nasa.gov/sites/default/files/styles/full_width/public/thumbnails/image/main_image_star-forming_region_carina_nircam_final-1280.jpg",
+  },
+  {
+    name: "aquarium",
+    imageURL: "https://i.ytimg.com/vi/dEZu8u8qPb8/maxresdefault.jpg",
+  },
+];
+
+export default headers;

--- a/src/assets/icons.js
+++ b/src/assets/icons.js
@@ -1,6 +1,6 @@
 let icons = [
-  { name: "star", image: "⭐️" },
-  { name: "frog", image: "🐸" },
+  { name: "star", image: "⭐️", representation: "⭐️" },
+  { name: "frog", image: "🐸", representation: "🐸" },
 ];
 
 export default icons;

--- a/src/assets/icons.js
+++ b/src/assets/icons.js
@@ -1,0 +1,6 @@
+let icons = [
+  { name: "star", image: "⭐️" },
+  { name: "frog", image: "🐸" },
+];
+
+export default icons;

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import EditableHeader from "../EditableHeader/EditableHeader";
 import EditableBlock from "../EditableBlock/EditableBlock";
 import "./App.css";
 
@@ -12,6 +13,7 @@ function App() {
 
   return (
     <main className="App">
+      <EditableHeader />
       <EditableBlock value={value} setValue={setValue} />
     </main>
   );

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -1,0 +1,7 @@
+.buttonElement {
+  opacity: 0;
+}
+
+.buttonElement:hover {
+  opacity: 1;
+}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,11 @@
+type ButtonProps = {
+  instruction: string;
+  buttonVisible: boolean;
+};
+
+export default function Button({ instruction, buttonVisible }: ButtonProps) {
+  if (buttonVisible === true) {
+    return <button>{instruction}</button>;
+  }
+  return null;
+}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,11 +1,36 @@
+import PopUp from "../PopUp/PopUp";
+import headers from "../../assets/headers.js";
+
 type ButtonProps = {
   instruction: string;
   buttonVisible: boolean;
+  visiblePop: boolean;
+  setVisiblePop: (value: boolean) => void;
+  setImage: (value: string) => void;
 };
 
-export default function Button({ instruction, buttonVisible }: ButtonProps) {
+export default function Button({
+  instruction,
+  buttonVisible,
+  visiblePop,
+  setVisiblePop,
+  setImage,
+}: ButtonProps) {
+  function onClick() {
+    setVisiblePop(!visiblePop);
+  }
   if (buttonVisible === true) {
-    return <button>{instruction}</button>;
+    return (
+      <>
+        <button onClick={onClick}>{instruction}</button>
+        <PopUp
+          visiblePop={visiblePop}
+          setVisiblePop={setVisiblePop}
+          setImage={setImage}
+          choices={headers}
+        />
+      </>
+    );
   }
   return null;
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,9 +1,9 @@
 import PopUp from "../PopUp/PopUp";
 import headers from "../../assets/headers.js";
+import "./Button.css";
 
 type ButtonProps = {
   instruction: string;
-  buttonVisible: boolean;
   visiblePop: boolean;
   setVisiblePop: (value: boolean) => void;
   setImage: (value: string) => void;
@@ -11,7 +11,6 @@ type ButtonProps = {
 
 export default function Button({
   instruction,
-  buttonVisible,
   visiblePop,
   setVisiblePop,
   setImage,
@@ -19,18 +18,17 @@ export default function Button({
   function onClick() {
     setVisiblePop(!visiblePop);
   }
-  if (buttonVisible === true) {
-    return (
-      <>
-        <button onClick={onClick}>{instruction}</button>
-        <PopUp
-          visiblePop={visiblePop}
-          setVisiblePop={setVisiblePop}
-          setImage={setImage}
-          choices={headers}
-        />
-      </>
-    );
-  }
-  return null;
+  return (
+    <>
+      <button onClick={onClick} className="buttonElement">
+        {instruction}
+      </button>
+      <PopUp
+        visiblePop={visiblePop}
+        setVisiblePop={setVisiblePop}
+        setImage={setImage}
+        choices={headers}
+      />
+    </>
+  );
 }

--- a/src/components/EditableHeader/EditableHeader.css
+++ b/src/components/EditableHeader/EditableHeader.css
@@ -1,11 +1,30 @@
+.EditableHeader {
+  display: block;
+}
+
 .headerImage {
   width: 100%;
   height: 10rem;
   object-fit: cover;
 }
 
+.headerImage:hover {
+  background-color: #d3d3d3;
+  cursor: hover;
+}
+
 .headerIcon {
   width: 75px;
   height: 75px;
   font-size: 75px;
+}
+
+.headerTitle {
+  background-color: transparent;
+  border: 0px;
+  outline: none;
+  padding: 0.5rem;
+  resize: none;
+  overflow: hidden;
+  font-size: 2rem;
 }

--- a/src/components/EditableHeader/EditableHeader.css
+++ b/src/components/EditableHeader/EditableHeader.css
@@ -1,0 +1,11 @@
+.headerImage {
+  width: 100%;
+  height: 10rem;
+  object-fit: cover;
+}
+
+.headerIcon {
+  width: 75px;
+  height: 75px;
+  font-size: 75px;
+}

--- a/src/components/EditableHeader/EditableHeader.tsx
+++ b/src/components/EditableHeader/EditableHeader.tsx
@@ -23,14 +23,14 @@ export default function EditableHeader() {
         src="https://www.nasa.gov/sites/default/files/styles/full_width/public/thumbnails/image/main_image_star-forming_region_carina_nircam_final-1280.jpg"
         className="headerImage"
       />
-      <span
-        className="headerIcon"
-        onClick={onClick}
-        visiblePop={visiblePop}
-        setIconImage={setIconImage}
-      >
+      <span className="headerIcon" onClick={onClick}>
         {iconImage}
       </span>
+      <PopUp
+        visiblePop={visiblePop}
+        setIconImage={setIconImage}
+        setVisiblePop={setVisiblePop}
+      />
       <input
         value={headerText}
         onChange={onChange}

--- a/src/components/EditableHeader/EditableHeader.tsx
+++ b/src/components/EditableHeader/EditableHeader.tsx
@@ -1,23 +1,35 @@
+import { useState } from "react";
 import "./EditableHeader.css";
 
 export default function EditableHeader() {
+  const [headerText, setHeaderText] = useState("Untitled");
+
+  function onChange(e: React.ChangeEvent) {
+    setHeaderText((e.target as HTMLTextAreaElement).value);
+  }
+
   return (
-    <>
+    <div className="EditableHeader">
       <img
         alt="Decorative header background."
         src="https://www.nasa.gov/sites/default/files/styles/full_width/public/thumbnails/image/main_image_star-forming_region_carina_nircam_final-1280.jpg"
         className="headerImage"
       />
       <span className="headerIcon">⭐️</span>
-      <h1>Title</h1>
-    </>
+      <input
+        value={headerText}
+        onChange={onChange}
+        maxLength={11}
+        className="headerTitle"
+      ></input>
+    </div>
   );
 }
 
-// - **Editable header zone:**
-//   - Static icon field. DONE.
-//     - Editable icon field.
-//   - Static title field. DONE.
-//     - Editable title field.
-//   - Static cover field. DONE.
-//     - Editable cover field.
+/* **Editable header zone:**
+- Editable icon field.
+    - Editable on click.
+- Editable cover field.
+    - Only editable through clicking on various buttons.
+Can manage this state through just this component? Maybe? I think? Nothing else on the wider page is able to affect it, and it's always visible on the page, so don't need state any higher?
+*/

--- a/src/components/EditableHeader/EditableHeader.tsx
+++ b/src/components/EditableHeader/EditableHeader.tsx
@@ -9,7 +9,6 @@ export default function EditableHeader() {
   const [iconImage, setIconImage] = useState("💌");
   const [visibleIconPop, setVisibleIconPop] = useState(false);
   const [visibleHeaderPop, setVisibleHeaderPop] = useState(false);
-  const [buttonVisible, setButtonVisible] = useState(false);
   const [headerImage, setHeaderImage] = useState(
     "https://www.northyorkmoors.org.uk/__data/assets/image/0032/117878/NYMR-steam-train-in-Newtondale_credit-Mike-Kipling-NYMNP.jpg"
   );
@@ -22,13 +21,9 @@ export default function EditableHeader() {
     setVisibleIconPop(!visibleIconPop);
   }
 
-  function onHover() {
-    setButtonVisible(true);
-  }
-
   return (
     <div className="EditableHeader">
-      <div onMouseOver={onHover} onMouseOut={onHover}>
+      <div>
         <img
           alt="Decorative header background."
           src={headerImage}
@@ -36,7 +31,6 @@ export default function EditableHeader() {
         />
         <Button
           instruction={"Click to change header."}
-          buttonVisible={buttonVisible}
           visiblePop={visibleHeaderPop}
           setVisiblePop={setVisibleHeaderPop}
           setImage={setHeaderImage}
@@ -61,11 +55,10 @@ export default function EditableHeader() {
   );
 }
 
-/* **Editable header zone:**
+/* 
+Version One finished!
+
+Version Two:
 - Editable icon field.
     - Need to make sure the set icon on the page is also set as the page favicon.
-- Editable cover field.
-    - On Notion, when you hover over the header cover, a button to 'Change cover' comes up.
-    - If you click to change cover, it brings up another pop up.
-    - You select the cover you want from the 'Gallery', and the cover updates.
 */

--- a/src/components/EditableHeader/EditableHeader.tsx
+++ b/src/components/EditableHeader/EditableHeader.tsx
@@ -1,11 +1,19 @@
 import { useState } from "react";
+import PopUp from "../PopUp/PopUp";
 import "./EditableHeader.css";
+import icons from "../../assets/icons.js";
 
 export default function EditableHeader() {
   const [headerText, setHeaderText] = useState("Untitled");
+  const [iconImage, setIconImage] = useState("💌");
+  const [visiblePop, setVisiblePop] = useState(false);
 
   function onChange(e: React.ChangeEvent) {
     setHeaderText((e.target as HTMLTextAreaElement).value);
+  }
+
+  function onClick() {
+    setVisiblePop(!visiblePop);
   }
 
   return (
@@ -15,7 +23,14 @@ export default function EditableHeader() {
         src="https://www.nasa.gov/sites/default/files/styles/full_width/public/thumbnails/image/main_image_star-forming_region_carina_nircam_final-1280.jpg"
         className="headerImage"
       />
-      <span className="headerIcon">⭐️</span>
+      <span
+        className="headerIcon"
+        onClick={onClick}
+        visiblePop={visiblePop}
+        setIconImage={setIconImage}
+      >
+        {iconImage}
+      </span>
       <input
         value={headerText}
         onChange={onChange}
@@ -27,9 +42,24 @@ export default function EditableHeader() {
 }
 
 /* **Editable header zone:**
-- Editable icon field.
-    - Editable on click.
+- Editable icon field. WORKING ON THIS NOW.
+    - You click the icon.
+    - A menu of other emoji icons comes up.
+    - You select from the icons.
+    - The icon is set as the icon in the header, and the icon in the metadata.
+    - There's a lot more functionality, and you can set images, but I can worry about this later.
+    So, recreating:
+        - You click on the icon.
+        - A menu comes up.
+        - Menu contains a dictionary of icons that you can select and use.
+        - On click, the selected icon is set as state for the main icon.
+        - This state should also be used to set the metadata of the EditablePage, so will need to be raised later?
 - Editable cover field.
     - Only editable through clicking on various buttons.
 Can manage this state through just this component? Maybe? I think? Nothing else on the wider page is able to affect it, and it's always visible on the page, so don't need state any higher?
+TODO:
+- Fix the onChange, so that it takes in different parameters, and can change states a few different ways.
+- Going to have to make a component for the pop up menu for emojis.
+
+I AM CURRENTLY TRYING TO HAND IN PROPS OF STATE TO THE SPAN SO THAT I CAN MAKE THE POP UP APPEAR AND SET THE SETICONHEADER STATE.
 */

--- a/src/components/EditableHeader/EditableHeader.tsx
+++ b/src/components/EditableHeader/EditableHeader.tsx
@@ -1,34 +1,50 @@
 import { useState } from "react";
 import PopUp from "../PopUp/PopUp";
+import Button from "../Button/Button";
 import "./EditableHeader.css";
 
 export default function EditableHeader() {
   const [headerText, setHeaderText] = useState("Untitled");
   const [iconImage, setIconImage] = useState("💌");
-  const [visiblePop, setVisiblePop] = useState(false);
+  const [visibleIconPop, setVisibleIconPop] = useState(false);
+  const [visibleHeaderPop, setVisibleHeaderPop] = useState(false);
+  const [buttonVisible, setButtonVisible] = useState(false);
+  const [headerImage, setHeaderImage] = useState(
+    "https://www.northyorkmoors.org.uk/__data/assets/image/0032/117878/NYMR-steam-train-in-Newtondale_credit-Mike-Kipling-NYMNP.jpg"
+  );
 
   function onChange(e: React.ChangeEvent) {
     setHeaderText((e.target as HTMLTextAreaElement).value);
   }
 
   function onClick() {
-    setVisiblePop(!visiblePop);
+    setVisibleIconPop(!visibleIconPop);
+  }
+
+  function onHover() {
+    setButtonVisible(!buttonVisible);
   }
 
   return (
     <div className="EditableHeader">
       <img
         alt="Decorative header background."
-        src="https://www.nasa.gov/sites/default/files/styles/full_width/public/thumbnails/image/main_image_star-forming_region_carina_nircam_final-1280.jpg"
+        src={headerImage}
         className="headerImage"
+        onMouseOver={onHover}
+        onMouseOut={onHover}
+      />
+      <Button
+        instruction={"Click to change header."}
+        buttonVisible={buttonVisible}
       />
       <span className="headerIcon" onClick={onClick}>
         {iconImage}
       </span>
       <PopUp
-        visiblePop={visiblePop}
-        setIconImage={setIconImage}
-        setVisiblePop={setVisiblePop}
+        visiblePop={visibleIconPop}
+        setVisiblePop={setVisibleIconPop}
+        setImage={setIconImage}
       />
       <input
         value={headerText}
@@ -41,10 +57,10 @@ export default function EditableHeader() {
 }
 
 /* **Editable header zone:**
-- Editable icon field. WORKING ON THIS NOW.
+- Editable icon field.
     - Need to make sure the set icon on the page is also set as the page favicon.
-    - There's a lot more functionality, and you can set images, but I can worry about this later.
 - Editable cover field.
-    - Only editable through clicking on various buttons.
-Can manage this state through just this component? Maybe? I think? Nothing else on the wider page is able to affect it, and it's always visible on the page, so don't need state any higher?
+    - On Notion, when you hover over the header cover, a button to 'Change cover' comes up.
+    - If you click to change cover, it brings up another pop up.
+    - You select the cover you want from the 'Gallery', and the cover updates.
 */

--- a/src/components/EditableHeader/EditableHeader.tsx
+++ b/src/components/EditableHeader/EditableHeader.tsx
@@ -1,0 +1,23 @@
+import "./EditableHeader.css";
+
+export default function EditableHeader() {
+  return (
+    <>
+      <img
+        alt="Decorative header background."
+        src="https://www.nasa.gov/sites/default/files/styles/full_width/public/thumbnails/image/main_image_star-forming_region_carina_nircam_final-1280.jpg"
+        className="headerImage"
+      />
+      <span className="headerIcon">⭐️</span>
+      <h1>Title</h1>
+    </>
+  );
+}
+
+// - **Editable header zone:**
+//   - Static icon field. DONE.
+//     - Editable icon field.
+//   - Static title field. DONE.
+//     - Editable title field.
+//   - Static cover field. DONE.
+//     - Editable cover field.

--- a/src/components/EditableHeader/EditableHeader.tsx
+++ b/src/components/EditableHeader/EditableHeader.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import PopUp from "../PopUp/PopUp";
 import "./EditableHeader.css";
-import icons from "../../assets/icons.js";
 
 export default function EditableHeader() {
   const [headerText, setHeaderText] = useState("Untitled");
@@ -43,23 +42,9 @@ export default function EditableHeader() {
 
 /* **Editable header zone:**
 - Editable icon field. WORKING ON THIS NOW.
-    - You click the icon.
-    - A menu of other emoji icons comes up.
-    - You select from the icons.
-    - The icon is set as the icon in the header, and the icon in the metadata.
+    - Need to make sure the set icon on the page is also set as the page favicon.
     - There's a lot more functionality, and you can set images, but I can worry about this later.
-    So, recreating:
-        - You click on the icon.
-        - A menu comes up.
-        - Menu contains a dictionary of icons that you can select and use.
-        - On click, the selected icon is set as state for the main icon.
-        - This state should also be used to set the metadata of the EditablePage, so will need to be raised later?
 - Editable cover field.
     - Only editable through clicking on various buttons.
 Can manage this state through just this component? Maybe? I think? Nothing else on the wider page is able to affect it, and it's always visible on the page, so don't need state any higher?
-TODO:
-- Fix the onChange, so that it takes in different parameters, and can change states a few different ways.
-- Going to have to make a component for the pop up menu for emojis.
-
-I AM CURRENTLY TRYING TO HAND IN PROPS OF STATE TO THE SPAN SO THAT I CAN MAKE THE POP UP APPEAR AND SET THE SETICONHEADER STATE.
 */

--- a/src/components/EditableHeader/EditableHeader.tsx
+++ b/src/components/EditableHeader/EditableHeader.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import PopUp from "../PopUp/PopUp";
 import Button from "../Button/Button";
 import "./EditableHeader.css";
+import icons from "../../assets/icons.js";
 
 export default function EditableHeader() {
   const [headerText, setHeaderText] = useState("Untitled");
@@ -22,22 +23,25 @@ export default function EditableHeader() {
   }
 
   function onHover() {
-    setButtonVisible(!buttonVisible);
+    setButtonVisible(true);
   }
 
   return (
     <div className="EditableHeader">
-      <img
-        alt="Decorative header background."
-        src={headerImage}
-        className="headerImage"
-        onMouseOver={onHover}
-        onMouseOut={onHover}
-      />
-      <Button
-        instruction={"Click to change header."}
-        buttonVisible={buttonVisible}
-      />
+      <div onMouseOver={onHover} onMouseOut={onHover}>
+        <img
+          alt="Decorative header background."
+          src={headerImage}
+          className="headerImage"
+        />
+        <Button
+          instruction={"Click to change header."}
+          buttonVisible={buttonVisible}
+          visiblePop={visibleHeaderPop}
+          setVisiblePop={setVisibleHeaderPop}
+          setImage={setHeaderImage}
+        />
+      </div>
       <span className="headerIcon" onClick={onClick}>
         {iconImage}
       </span>
@@ -45,6 +49,7 @@ export default function EditableHeader() {
         visiblePop={visibleIconPop}
         setVisiblePop={setVisibleIconPop}
         setImage={setIconImage}
+        choices={icons}
       />
       <input
         value={headerText}

--- a/src/components/PopUp/PopUp.css
+++ b/src/components/PopUp/PopUp.css
@@ -1,7 +1,9 @@
 .PopUpContainer {
-  width: 500px;
-  height: 500px;
+  width: 300px;
+  height: 200px;
   background-color: gainsboro;
+  position: absolute;
+  left: 35%;
 }
 
 .iconContainer {

--- a/src/components/PopUp/PopUp.css
+++ b/src/components/PopUp/PopUp.css
@@ -1,0 +1,9 @@
+.PopUpContainer {
+  width: 500px;
+  height: 500px;
+  background-color: gainsboro;
+}
+
+.iconContainer {
+  border: solid 1px red;
+}

--- a/src/components/PopUp/PopUp.tsx
+++ b/src/components/PopUp/PopUp.tsx
@@ -1,0 +1,22 @@
+import icons from "../../assets/icons.js";
+
+type PopUpProps = {
+  visiblePop: boolean;
+  setIconHeader: (value: string) => void;
+};
+
+export default function PopUp({ visiblePop, setIconHeader }: PopUpProps) {
+  // function onClick(e) {
+  //     setIconHeader(e.target.value);
+  // }
+  if (visiblePop === true) {
+    return (
+      <div>
+        <p>Click to select an icon.</p>
+        {icons.map((icon) => (
+          <span>{icon.image}</span>
+        ))}
+      </div>
+    );
+  }
+}

--- a/src/components/PopUp/PopUp.tsx
+++ b/src/components/PopUp/PopUp.tsx
@@ -1,21 +1,23 @@
-import icons from "../../assets/icons.js";
 import "./PopUp.css";
 
 type PopUpProps = {
   visiblePop: boolean;
   setVisiblePop: (value: boolean) => void;
   setImage: (value: string) => void;
+  choices: any;
 };
 
 interface iconProps {
   name: string;
   image: string;
+  representation: string;
 }
 
 export default function PopUp({
   visiblePop,
   setVisiblePop,
   setImage,
+  choices,
 }: PopUpProps): JSX.Element | null {
   function onClick(event: React.MouseEvent<HTMLButtonElement>) {
     setImage((event.target as HTMLButtonElement).value);
@@ -25,14 +27,14 @@ export default function PopUp({
   if (visiblePop === true) {
     return (
       <div className="PopUpContainer">
-        <p>Click to select an icon.</p>
-        {icons.map((icon: iconProps) => (
+        <p>Click to select.</p>
+        {choices.map((choice: iconProps) => (
           <button
             onClick={onClick}
             className="iconContainer"
-            value={icon.image}
+            value={choice.image}
           >
-            {icon.image}
+            {choice.representation}
           </button>
         ))}
       </div>

--- a/src/components/PopUp/PopUp.tsx
+++ b/src/components/PopUp/PopUp.tsx
@@ -4,7 +4,7 @@ import "./PopUp.css";
 type PopUpProps = {
   visiblePop: boolean;
   setVisiblePop: (value: boolean) => void;
-  setIconImage: (value: string) => void;
+  setImage: (value: string) => void;
 };
 
 interface iconProps {
@@ -15,10 +15,10 @@ interface iconProps {
 export default function PopUp({
   visiblePop,
   setVisiblePop,
-  setIconImage,
+  setImage,
 }: PopUpProps): JSX.Element | null {
   function onClick(event: React.MouseEvent<HTMLButtonElement>) {
-    setIconImage((event.target as HTMLButtonElement).value);
+    setImage((event.target as HTMLButtonElement).value);
     setVisiblePop(false);
   }
 

--- a/src/components/PopUp/PopUp.tsx
+++ b/src/components/PopUp/PopUp.tsx
@@ -2,21 +2,40 @@ import icons from "../../assets/icons.js";
 
 type PopUpProps = {
   visiblePop: boolean;
-  setIconHeader: (value: string) => void;
+  setVisiblePop: (value: boolean) => void;
+  setIconImage: (value: string) => void;
 };
 
-export default function PopUp({ visiblePop, setIconHeader }: PopUpProps) {
-  // function onClick(e) {
-  //     setIconHeader(e.target.value);
-  // }
+interface iconProps {
+  name: string;
+  image: string;
+}
+
+export default function PopUp({
+  visiblePop,
+  setVisiblePop,
+  setIconImage,
+}: PopUpProps): JSX.Element | null {
+  function onClick(event: React.MouseEvent<HTMLButtonElement>) {
+    setIconImage((event.target as HTMLButtonElement).value);
+    setVisiblePop(false);
+  }
+
   if (visiblePop === true) {
     return (
-      <div>
+      <div className="PopUpContainer">
         <p>Click to select an icon.</p>
-        {icons.map((icon) => (
-          <span>{icon.image}</span>
+        {icons.map((icon: iconProps) => (
+          <button
+            onClick={onClick}
+            className="iconContainer"
+            value={icon.image}
+          >
+            {icon.image}
+          </button>
         ))}
       </div>
     );
   }
+  return null;
 }

--- a/src/components/PopUp/PopUp.tsx
+++ b/src/components/PopUp/PopUp.tsx
@@ -1,4 +1,5 @@
 import icons from "../../assets/icons.js";
+import "./PopUp.css";
 
 type PopUpProps = {
   visiblePop: boolean;


### PR DESCRIPTION
Created `EditableHeader` component, got static version done, and first editable version. A bit messy and missing a lot of the extra functionality Notion's version has, but it'll do for the first try.

To support `EditableHeader` component, have also created: `Button` and `PopUp` components. Also a bit messy, but one nice learning moment (documented in `LOG.md` if notes needed) is that component reusability is starting to get a lot easier. Got it conceptually previously, but struggled putting it into practice, so that's fun!

Learned some fun new stuff from looking at the Notion code! Notes in `LOG.md`.

Everything needs CSS doing because it looks very in progress, but will do that separately.