### PR TITLE
New component call.

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -171,3 +171,4 @@ TODO:
 Thu 15th Sept
 
 - Setting autoFocus on inputs and textareas can make you automatically focus on those elements, but it's a bit glitchy. Having the issue of state inner content copying to each new copy of a component, which is adding in extra spaces to each new component too, I think.
+- [This article was helpful.](https://blog.maisie.ink/react-ref-autofocus/)

--- a/LOG.md
+++ b/LOG.md
@@ -167,3 +167,7 @@ TODO:
 - Check types and interfaces are correct and fitting.
 - Clean up logs and readme.
 - Work on editable block.
+
+Thu 15th Sept
+
+- Setting autoFocus on inputs and textareas can make you automatically focus on those elements, but it's a bit glitchy. Having the issue of state inner content copying to each new copy of a component, which is adding in extra spaces to each new component too, I think.

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -25,12 +25,6 @@ function App() {
           />
         ))}
       </div>
-      <EditableBlock
-        value={value}
-        setValue={setValue}
-        components={components}
-        setComponents={setComponents}
-      />
     </main>
   );
 }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -9,13 +9,8 @@ function App() {
     setValue: any;
   }
 
-  interface pageComponents {
-    components: any;
-    setComponents: (value: any) => void;
-  }
-
   const [value, setValue] = useState<editableValue>();
-  const [components, setComponents] = useState<pageComponents>(["Tester"]);
+  const [components, setComponents] = useState(["Tester"]);
 
   function addComponent() {
     setComponents([...components, "Test Component"]);
@@ -25,6 +20,12 @@ function App() {
     <main className="App">
       <EditableHeader />
       <EditableBlock value={value} setValue={setValue} />
+      <div>
+        <button onClick={addComponent}>Call Component</button>
+        {components.map((item, i) => (
+          <EditableBlock value={value} setValue={setValue} />
+        ))}
+      </div>
     </main>
   );
 }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,4 +1,4 @@
-import { SetStateAction, useState } from "react";
+import { useState } from "react";
 import EditableHeader from "../EditableHeader/EditableHeader";
 import EditableBlock from "../EditableBlock/EditableBlock";
 import "./App.css";
@@ -12,20 +12,25 @@ function App() {
   const [value, setValue] = useState<editableValue>();
   const [components, setComponents] = useState(["Tester"]);
 
-  function addComponent() {
-    setComponents([...components, "Test Component"]);
-  }
-
   return (
     <main className="App">
       <EditableHeader />
-      <EditableBlock value={value} setValue={setValue} />
       <div>
-        <button onClick={addComponent}>Call Component</button>
-        {components.map((item, i) => (
-          <EditableBlock value={value} setValue={setValue} />
+        {components.map(() => (
+          <EditableBlock
+            value={value}
+            setValue={setValue}
+            components={components}
+            setComponents={setComponents}
+          />
         ))}
       </div>
+      <EditableBlock
+        value={value}
+        setValue={setValue}
+        components={components}
+        setComponents={setComponents}
+      />
     </main>
   );
 }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { SetStateAction, useState } from "react";
 import EditableHeader from "../EditableHeader/EditableHeader";
 import EditableBlock from "../EditableBlock/EditableBlock";
 import "./App.css";
@@ -9,7 +9,17 @@ function App() {
     setValue: any;
   }
 
+  interface pageComponents {
+    components: any;
+    setComponents: (value: any) => void;
+  }
+
   const [value, setValue] = useState<editableValue>();
+  const [components, setComponents] = useState<pageComponents>(["Tester"]);
+
+  function addComponent() {
+    setComponents([...components, "Test Component"]);
+  }
 
   return (
     <main className="App">
@@ -20,3 +30,12 @@ function App() {
 }
 
 export default App;
+
+/*
+AIMS:
+- we create a state that tracks how many components we have
+- on a certain input, we add another component to the array of components tracked in state
+- we render those components on screen
+- we can later take those components away from the array
+- this is meant to mimic how, on enter in notion, a new component comes onto screen
+*/

--- a/src/components/EditableBlock/EditableBlock.css
+++ b/src/components/EditableBlock/EditableBlock.css
@@ -1,6 +1,6 @@
 .EditableBlock {
   background-color: transparent;
-  border: 0px;
+  border: 1px solid red;
   outline: none;
   padding: 0.5rem;
   resize: none;

--- a/src/components/EditableBlock/EditableBlock.tsx
+++ b/src/components/EditableBlock/EditableBlock.tsx
@@ -51,6 +51,7 @@ export default function EditableBlock({
       onBlur={onBlur}
       rows={1}
       className="EditableBlock"
+      autoFocus
     ></textarea>
   );
 }

--- a/src/components/EditableBlock/EditableBlock.tsx
+++ b/src/components/EditableBlock/EditableBlock.tsx
@@ -4,10 +4,22 @@ import "./EditableBlock.css";
 type EditableBlockProps = {
   value: any;
   setValue: (value: any) => void;
+  components: any;
+  setComponents: any;
 };
 
-export default function EditableBlock({ value, setValue }: EditableBlockProps) {
+export default function EditableBlock({
+  value,
+  setValue,
+  components,
+  setComponents,
+}: EditableBlockProps) {
   const [editingValue, setEditingValue] = useState(value);
+
+  function addComponent() {
+    setComponents([...components, "Test Component"]);
+  }
+
   function onChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
     setEditingValue(e.target.value);
   }
@@ -26,6 +38,7 @@ export default function EditableBlock({ value, setValue }: EditableBlockProps) {
   function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === "Enter" || e.key === "Escape") {
       (e.target as HTMLTextAreaElement).blur();
+      addComponent();
     }
   }
 


### PR DESCRIPTION
Added functionality where, on pressing enter, a new copy of the `EditableBlock` component is called on a new block under the currently occupied block.

It's not very tidy and there's a problem with the state for the inner content persisting on each new component call. Eg. if you have text already in the component you're in when you press enter, it will copy to the new one that clones. I think this is why we're getting the weird problem of extra paragraph lines adding to new empty component copies. Will address going forward.