### PR TITLE
Started removing persisting state from EditableBlock.

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -9,7 +9,7 @@ function App() {
     setValue: any;
   }
 
-  const [value, setValue] = useState<editableValue>();
+  // const [value, setValue] = useState<editableValue>();
   const [components, setComponents] = useState(["Tester"]);
 
   return (
@@ -18,8 +18,8 @@ function App() {
       <div>
         {components.map(() => (
           <EditableBlock
-            value={value}
-            setValue={setValue}
+            // value={value}
+            // setValue={setValue}
             components={components}
             setComponents={setComponents}
           />

--- a/src/components/EditableBlock/EditableBlock.tsx
+++ b/src/components/EditableBlock/EditableBlock.tsx
@@ -2,18 +2,24 @@ import { useState } from "react";
 import "./EditableBlock.css";
 
 type EditableBlockProps = {
-  value: any;
-  setValue: (value: any) => void;
+  value: string;
+  setValue: (value: string) => void;
   components: any;
   setComponents: any;
 };
 
+interface editableValue {
+  value: string;
+  setValue: string;
+}
+
 export default function EditableBlock({
-  value,
-  setValue,
+  // value,
+  // setValue,
   components,
   setComponents,
 }: EditableBlockProps) {
+  const [value, setValue] = useState<editableValue>();
   const [editingValue, setEditingValue] = useState(value);
 
   function addComponent() {


### PR DESCRIPTION
Having an issue where, when EditableBlock is duplicated, the text or entries inside of the block persist, as the state is handed down and duplicated. The blocks can then be edited separate to each other once they've been duplicated, and seem to work just fine. The duplication is throwing up problems, though.

Update: had a brainwave, I was over-complicating it. Will open new PR from new branch for working fix.