### PR TITLE
Fixed textarea bugs and state.

### DIFF
--- a/src/components/EditableBlock/EditableBlock.tsx
+++ b/src/components/EditableBlock/EditableBlock.tsx
@@ -37,10 +37,12 @@ export default function EditableBlock({
   }
 
   function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === "Enter" || e.key === "Escape") {
+    if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       (e.target as HTMLTextAreaElement).blur();
       addComponent();
+    } else if (e.key === "Escape") {
+      (e.target as HTMLTextAreaElement).blur();
     }
   }
 

--- a/src/components/EditableBlock/EditableBlock.tsx
+++ b/src/components/EditableBlock/EditableBlock.tsx
@@ -18,6 +18,7 @@ export default function EditableBlock({
 
   function addComponent() {
     setComponents([...components, "Test Component"]);
+    setValue("");
   }
 
   function onChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
@@ -37,6 +38,7 @@ export default function EditableBlock({
 
   function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === "Enter" || e.key === "Escape") {
+      e.preventDefault();
       (e.target as HTMLTextAreaElement).blur();
       addComponent();
     }


### PR DESCRIPTION
Was having an issue where, on calling a new `EditableBlock` component, the state inside both components would match. Also, on calling a new `EditableBlock` - which was a `textarea` - a new line would populate on each new component.

Fixed the state issue by calling `setValue()` inside the `addComponent` function, to reset the new value of the new component.

Fixed the `textarea` problem by calling `preventDefault()` on the press enter event. If enter is pressed without the shift key, the new component will populate. If enter is pressed with shift, you will move onto a new line within the same `textarea` you were already in. If you press escape, your focus will blur but no new component will call.